### PR TITLE
Fix missing type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import {SpeechMarkdown as SMD} from 'speechmarkdown-js';
 
-declare module 'jovo-core/dist/src/Jovo' {
+declare module 'jovo-core/dist/src/core/Jovo' {
     interface Jovo {
         $speechMarkdown?: SMD;
     }


### PR DESCRIPTION
Fixes `Property '$speechMarkdown' does not exist on type 'Jovo'.`  error in Typescript Jovo project.

I updated the path after it was changed in Jovo.